### PR TITLE
"kind" attribute added to steps & load yaml issue fixed

### DIFF
--- a/examples/llama_user.py
+++ b/examples/llama_user.py
@@ -1,4 +1,5 @@
 import json
+from typing import Literal
 
 from tapeagents.agent import ObservationMaker
 from tapeagents.core import AgentEvent, MakeObservation, Observation, Prompt, Tape
@@ -26,10 +27,12 @@ ONLY output this JSON and nothing else."""
 
 
 class UserModelFreeFormThought(Observation):
+    kind: Literal["user_model_free_form_thought"] = "user_model_free_form_thought"
     content: str
 
 
 class UserModelInstruction(Observation):
+    kind: Literal["user_model_instruction"] = "user_model_instruction"
     instruction: str
 
 

--- a/tapeagents/core.py
+++ b/tapeagents/core.py
@@ -61,7 +61,7 @@ class PartialStep(BaseModel):
 
 
 class Observation(Step):
-    pass
+    kind: str = "observation"
 
 
 class Error(Observation):
@@ -69,7 +69,7 @@ class Error(Observation):
 
 
 class AgentStep(Step):
-    pass
+    kind: str = "agent_step"
 
 
 class Thought(AgentStep):
@@ -255,4 +255,5 @@ ObservationMakerTapeType = TypeVar("ObservationMakerTapeType", bound=Tape)
 
 
 class MakeObservation(Action, Generic[StepType]):
+    kind: Literal["make_observation"] = "make_observation"
     new_observation: StepType

--- a/tapeagents/core.py
+++ b/tapeagents/core.py
@@ -41,6 +41,7 @@ class StepMetadata(BaseModel):
 
 class Step(BaseModel):
     metadata: StepMetadata = StepMetadata()
+    kind: Literal["define_me"] = "define_me" # This is a placeholder value, it should be overwritten in subclasses
 
     def llm_dict(self) -> dict[str, Any]:
         """Dump step data only, drop the metadata"""
@@ -61,7 +62,7 @@ class PartialStep(BaseModel):
 
 
 class Observation(Step):
-    kind: Literal["observation"] = "observation"
+    pass
 
 
 class Error(Observation):
@@ -69,7 +70,7 @@ class Error(Observation):
 
 
 class AgentStep(Step):
-    kind: Literal["agent_step"] = "agent_step"
+    pass
 
 
 class Thought(AgentStep):

--- a/tapeagents/core.py
+++ b/tapeagents/core.py
@@ -61,7 +61,7 @@ class PartialStep(BaseModel):
 
 
 class Observation(Step):
-    kind: str = "observation"
+    kind: Literal["observation"] = "observation"
 
 
 class Error(Observation):
@@ -69,7 +69,7 @@ class Error(Observation):
 
 
 class AgentStep(Step):
-    kind: str = "agent_step"
+    kind: Literal["agent_step"] = "agent_step"
 
 
 class Thought(AgentStep):

--- a/tapeagents/dialog_tape.py
+++ b/tapeagents/dialog_tape.py
@@ -138,10 +138,12 @@ DialogEvent: TypeAlias = AgentEvent[DialogTape]
 
 
 class AnnotatorFreeFormThought(Thought):
+    kind: Literal["annotator_free_form_thought"] = "annotator_free_form_thought"
     content: str
 
 
 class AnnotationAction(Action):
+    kind: Literal["annotation_action"] = "annotation_action"
     annotation: dict
 
 

--- a/tapeagents/io.py
+++ b/tapeagents/io.py
@@ -71,7 +71,7 @@ def load_tapes(tape_class: Type | TypeAdapter, path: Path | str, file_extension:
     for path in paths:
         with open(path) as f:
             if file_extension == ".yaml":
-                data = yaml.safe_load_all(f)
+                data = list(yaml.safe_load_all(f))
             else:
                 data = json.load(f)
         if not isinstance(data, list):


### PR DESCRIPTION
This PR addresses two problems:
- Fixes a problem in "load_tapes" in `io.py`: For loading a yaml file, `yaml.safe_load_all(f)` returns a generator, which forces the next line to wrap the loaded records inside another list, which is not necessary.
- "kind" attribute added to `AgentStep` and `Observation`: This is to fix an inconsistency issue in `add_step` in `TapeView` where it is assumed all steps have "kind".