### PR TITLE
do not modify input tape metadata in agent.run()

### DIFF
--- a/tapeagents/agent.py
+++ b/tapeagents/agent.py
@@ -355,6 +355,7 @@ class Agent(BaseModel, Generic[TapeType]):
             nonlocal tape
             n_iterations = 0
             input_tape_length = len(tape)
+            input_tape_id = tape.metadata.id
             stop = False
             while n_iterations < max_iterations and not stop:
                 current_subagent = self.delegate(tape)
@@ -372,8 +373,7 @@ class Agent(BaseModel, Generic[TapeType]):
                 n_iterations += 1
             updated_metadata = tape.metadata.model_copy(
                 update=dict(
-                    id=str(uuid4()),
-                    parent_id=tape.metadata.id,
+                    parent_id=input_tape_id,
                     author=self.name,
                     n_added_steps=len(tape) - input_tape_length,
                 )

--- a/tapeagents/agent.py
+++ b/tapeagents/agent.py
@@ -353,7 +353,6 @@ class Agent(BaseModel, Generic[TapeType]):
         def _run_implementation():
             nonlocal tape
             n_iterations = 0
-            input_tape_length = len(tape)
             stop = False
             while n_iterations < max_iterations and not stop:
                 current_subagent = self.delegate(tape)
@@ -373,7 +372,6 @@ class Agent(BaseModel, Generic[TapeType]):
                 id=str(uuid4()),
                 parent_id=tape.metadata.id,
                 author=self.name,
-                n_added_steps=len(tape) - input_tape_length,
             ))
             final_tape = tape.model_copy(update=dict(metadata=updated_metadata))
             yield AgentEvent(final_tape=final_tape)

--- a/tapeagents/core.py
+++ b/tapeagents/core.py
@@ -165,7 +165,7 @@ class Tape(BaseModel, Generic[ContextType, StepType]):
     def __iter__(self) -> Iterator[StepType]:  # type: ignore
         return iter(self.steps)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.steps)
 
     def __getitem__(self, key: int | slice) -> StepType | Self:
@@ -187,7 +187,7 @@ class Tape(BaseModel, Generic[ContextType, StepType]):
 
     def append(self, step: StepType) -> Self:
         """
-        Add a step to the tape
+        Add a step to the tape and increment metadata.n_added_steps
         """
         metadata = self.metadata.model_copy(update=dict(n_added_steps=self.metadata.n_added_steps + 1))
         return self.model_copy(update=dict(steps=self.steps + [step], metadata=metadata))

--- a/tapeagents/core.py
+++ b/tapeagents/core.py
@@ -187,10 +187,9 @@ class Tape(BaseModel, Generic[ContextType, StepType]):
 
     def append(self, step: StepType) -> Self:
         """
-        Add a step to the tape and increment metadata.n_added_steps
+        Add a step to the tape and creates new metadata (new tape id, etc...).
         """
-        metadata = self.metadata.model_copy(update=dict(n_added_steps=self.metadata.n_added_steps + 1))
-        return self.model_copy(update=dict(steps=self.steps + [step], metadata=metadata))
+        return self.model_copy(update=dict(steps=self.steps + [step], metadata=TapeMetadata()))
 
     def with_new_id(self) -> Self:
         return self.model_copy(update=dict(metadata=TapeMetadata()))

--- a/tapeagents/core.py
+++ b/tapeagents/core.py
@@ -189,7 +189,8 @@ class Tape(BaseModel, Generic[ContextType, StepType]):
         """
         Add a step to the tape
         """
-        return self.model_copy(update=dict(steps=self.steps + [step], metadata=TapeMetadata(n_added_steps=1)))
+        metadata = self.metadata.model_copy(update=dict(n_added_steps=self.metadata.n_added_steps + 1))
+        return self.model_copy(update=dict(steps=self.steps + [step], metadata=metadata))
 
     def with_new_id(self) -> Self:
         return self.model_copy(update=dict(metadata=TapeMetadata()))

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -381,6 +381,8 @@ def test_run():
         if event.final_tape:
             final_tape = event.final_tape
             break
+    # check that the tape metadata is the same
+    assert tape.metadata == initial_tape_meatadata
     # check that the metadata is updated correclty
     assert final_tape.metadata.parent_id == initial_tape_meatadata.id
     assert final_tape.metadata.n_added_steps == 1

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -377,11 +377,8 @@ def test_run_metadata():
     initial_tape_metadata = copy.deepcopy(tape.metadata)
     assert initial_tape_metadata.n_added_steps == 0
 
-    final_tape: MockTape = None
-    for event in agent.run(tape):
-        if event.final_tape:
-            final_tape = event.final_tape
-            break
+    final_tape = agent.run(tape).get_final_tape()
+
     # check that the original tape metadata is the same
     assert tape.metadata == initial_tape_metadata
     # check that the new tape metadata is updated correclty

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -96,6 +96,9 @@ def test_append_single_step():
     assert result.steps[-1] == new_step
     assert isinstance(result, Tape)
     assert result.metadata.n_added_steps == 1
+    # check that metadata is the same, except for n_added_steps
+    result.metadata.n_added_steps = 0
+    assert result.metadata == tape.metadata
 
 
 def test_append_multiple_steps():
@@ -109,7 +112,10 @@ def test_append_multiple_steps():
     assert result.steps[-2] == new_step1
     assert result.steps[-1] == new_step2
     assert isinstance(result, Tape)
-    assert result.metadata.n_added_steps == 1  # Only the last append's metadata is considered
+    assert result.metadata.n_added_steps == 2
+    # check that metadata is the same, except for n_added_steps
+    result.metadata.n_added_steps = 0
+    assert result.metadata == tape.metadata
 
 
 def test_append_to_empty_tape():
@@ -122,6 +128,9 @@ def test_append_to_empty_tape():
     assert result.steps[0] == new_step
     assert isinstance(result, Tape)
     assert result.metadata.n_added_steps == 1
+    # check that metadata is the same, except for n_added_steps
+    result.metadata.n_added_steps = 0
+    assert result.metadata == tape.metadata
 
 
 def test_with_new_id():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -95,10 +95,8 @@ def test_append_single_step():
     assert len(result.steps) == 2
     assert result.steps[-1] == new_step
     assert isinstance(result, Tape)
-    assert result.metadata.n_added_steps == 1
-    # check that metadata is the same, except for n_added_steps
-    result.metadata.n_added_steps = 0
-    assert result.metadata == tape.metadata
+    # check that metadata is the same as a brand new one
+    assert result.metadata == TapeMetadata(id=result.metadata.id)
 
 
 def test_append_multiple_steps():
@@ -112,10 +110,8 @@ def test_append_multiple_steps():
     assert result.steps[-2] == new_step1
     assert result.steps[-1] == new_step2
     assert isinstance(result, Tape)
-    assert result.metadata.n_added_steps == 2
-    # check that metadata is the same, except for n_added_steps
-    result.metadata.n_added_steps = 0
-    assert result.metadata == tape.metadata
+    # check that metadata is the same as a brand new one
+    assert result.metadata == TapeMetadata(id=result.metadata.id)
 
 
 def test_append_to_empty_tape():
@@ -127,10 +123,8 @@ def test_append_to_empty_tape():
     assert len(result.steps) == 1
     assert result.steps[0] == new_step
     assert isinstance(result, Tape)
-    assert result.metadata.n_added_steps == 1
-    # check that metadata is the same, except for n_added_steps
-    result.metadata.n_added_steps = 0
-    assert result.metadata == tape.metadata
+    # check that metadata is the same as a brand new one
+    assert result.metadata == TapeMetadata(id=result.metadata.id)
 
 
 def test_with_new_id():


### PR DESCRIPTION
- update `tape.append` to create a new TapeMetadata() object without setting `n_added_steps` as this variable will be set by the code that called .append()

- update `agent.run` to return a `model_copy` of the original tape with _updated_ metadata. Before we would return the same tape object with new TapeMetadata() instance. In cases where we would never call `tape.append()` (hence never creating a new tape variable with new metadata) this would have modified the original tape object passed to agent.run()

- set `final_tape.metadata.parent_id` to the tape id of the input tape passed to agent.run(). Before, we would set the parent_id to the id of the intermediate tape that resulted from the last call to `tape.append()` 