### PR TITLE
Record unparsable steps in tape

### DIFF
--- a/examples/openai_function_calling_demo.py
+++ b/examples/openai_function_calling_demo.py
@@ -1,14 +1,13 @@
 from tapeagents.demo import Demo
-from tapeagents.dialog_tape import DialogTape, DialogContext
-from tapeagents.environment import MockToolEnvironment
+from tapeagents.dialog_tape import DialogContext, DialogTape
 from tapeagents.llms import LiteLLM
 from tapeagents.rendering import BasicRenderer
 
-from .openai_function_calling import TOOL_SCHEMAS, FunctionCallingAgent
+from .openai_function_calling import TOOL_SCHEMAS, FunctionCallingAgent, MockToolEnvironment
 
 
 def try_openai_function_calling_interactive_demo():
-    llm = LiteLLM(model_name="gpt-3.5-turbo")    
+    llm = LiteLLM(model_name="gpt-3.5-turbo")
     agent = FunctionCallingAgent.create(llm)
     tape = DialogTape(context=DialogContext(tools=TOOL_SCHEMAS), steps=[])
     environment = MockToolEnvironment(llm)

--- a/tapeagents/agent.py
+++ b/tapeagents/agent.py
@@ -400,7 +400,6 @@ class Agent(BaseModel, Generic[TapeType]):
                 current_agent = self.delegate(past_tape)
                 prompt = current_agent.make_prompt(past_tape)
                 if not prompt:
-                    logger.debug("Skipping step because agent did not call the llm")
                     reused_steps.append(step)
                     i += 1
                     continue

--- a/tapeagents/core.py
+++ b/tapeagents/core.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 import json
-from typing import Any, Generic, Iterable, Iterator, Literal, TypeAlias, TypeVar, List
+from typing import Any, Generic, Iterable, Iterator, List, Literal, TypeAlias, TypeVar
 from uuid import uuid4
 
 import litellm
@@ -52,7 +52,7 @@ class StepMetadata(BaseModel):
 
 class Step(BaseModel):
     metadata: StepMetadata = StepMetadata()
-    kind: Literal["define_me"] = "define_me" # This is a placeholder value, it should be overwritten in subclasses
+    kind: Literal["define_me"] = "define_me"  # This is a placeholder value, it should be overwritten in subclasses
 
     def llm_dict(self) -> dict[str, Any]:
         """Dump step data only, drop the metadata"""
@@ -99,6 +99,7 @@ class LLMOutputParsingFailureAction(Action):
 
     kind: Literal["llm_output_parsing_failure_action"] = "llm_output_parsing_failure_action"
     error: str
+    llm_output: str
 
 
 class StopStep(Action):
@@ -138,7 +139,6 @@ class Respond(Thought):
 StepType = TypeVar("StepType", bound=Action | Observation | Thought)
 
 
-
 class TapeMetadata(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid4()))
     parent_id: str | None = None
@@ -147,7 +147,6 @@ class TapeMetadata(BaseModel):
     n_added_steps: int = 0
     error: Any | None = None
     result: Any = {}
-    
 
 
 ContextType = TypeVar("ContextType")

--- a/tapeagents/environment.py
+++ b/tapeagents/environment.py
@@ -5,16 +5,14 @@ from typing import Callable, Generic, Literal
 
 from langchain_core.tools import BaseTool, tool
 from langchain_core.utils.function_calling import convert_to_openai_tool
-from litellm.utils import Function
 from pydantic import TypeAdapter
 
 from tapeagents.container_executor import CodeBlock, CommandLineCodeResult, ContainerExecutor
 from tapeagents.utils import FatalError
 
 from .agent import TapeType
-from .core import Action, Observation, Prompt, Tape
+from .core import Action, Observation, Tape
 from .dialog_tape import AssistantStep, DialogTape, FunctionCall, ToolCalls, ToolResult, ToolSpec
-from .llms import LiteLLM
 
 logger = logging.getLogger(__name__)
 
@@ -53,19 +51,6 @@ class Environment(ABC, Generic[TapeType]):
         raise ValueError(f"Unexpected action type: {action}")
 
 
-MOCK_TOOL_ENV_PROMPT_TEMPLATE = """You will generate result of the following function call
-
-{function_call}
-
-You will output JSON of the following structure:
-{{
-    "result": ...
-}}
-
-You will output just the JSON and nothing else. Go!
-"""
-
-
 class EmptyEnvironment(Environment):
     def react(self, tape: Tape) -> list[Observation]:
         # TOOD: move prompting to a separate agent?
@@ -77,38 +62,9 @@ class EmptyEnvironment(Environment):
         return []
 
 
-class MockToolEnvironment(Environment):
-    def __init__(self, llm: LiteLLM):
-        self.llm = llm
-
-    def react(self, tape: DialogTape) -> DialogTape:
-        # TODO: move prompting to a separate agent?
-        action = tape.steps[-1]
-        assert isinstance(action, Action)
-        if isinstance(action, ToolCalls):
-            for tc in action.tool_calls:
-                prompt_text = MOCK_TOOL_ENV_PROMPT_TEMPLATE.format(function_call=tc.function)
-                messages = [{"role": "user", "content": prompt_text}]
-                for event in self.llm.generate(Prompt(messages=messages)):
-                    completion = event.output
-                    if completion and not isinstance(completion, str):
-                        completion = completion.content
-                    if completion:
-                        result_json = json.loads(completion)
-                        if not "result" in result_json:
-                            raise ValueError("Result JSON should have 'result' key")
-                        observation = ToolResult(content=json.dumps(result_json["result"]), tool_call_id=tc.id)
-                        tape = tape.append(observation)
-        elif isinstance(action, AssistantStep):
-            self.raise_external_observation_needed(action)
-        else:
-            self.raise_unexpected_action(action)
-        return tape
-
-
 class ToolEnvironment(Environment):
     def __init__(self, tools: list[BaseTool | Callable]):
-        self.tools = [t if isinstance(t, BaseTool) else tool(t) for t in tools]
+        self.tools: list[BaseTool] = [t if isinstance(t, BaseTool) else tool(t) for t in tools]  # type: ignore
         self._name2tool = {t.name: t for t in self.tools}
 
     def get_tool_schemas(self) -> list[ToolSpec]:
@@ -130,7 +86,7 @@ class ToolEnvironment(Environment):
             if isinstance(action, ToolCalls):
                 for tc in action.tool_calls:
                     if not isinstance(tc.function, FunctionCall) or not isinstance(tc.function.name, str):
-                        raise ValueError(f"Tool call must be Function and must have a name")
+                        raise ValueError("Tool call must be Function and must have a name")
                     tool = self._name2tool[tc.function.name]
                     args = tc.function.arguments
                     if isinstance(args, str):

--- a/tapeagents/nodes.py
+++ b/tapeagents/nodes.py
@@ -52,6 +52,9 @@ class MonoNode(Node):
         return tape.model_copy(update=dict(steps=steps_without_control_flow))
 
     def make_llm_output(self, agent: Any, tape: Tape, index: int) -> LLMOutput:
+        """
+        Make output from steps produced by the single llm call (having the same prompt_id), except for SetNextNode steps.
+        """
         steps = []
         i = index
         first_prompt_id = tape.steps[i].metadata.prompt_id
@@ -60,6 +63,7 @@ class MonoNode(Node):
                 steps.append(tape.steps[i])
             i += 1
 
+        # if there is only one step, return it as a single dict, not a list
         content = [step.llm_dict() for step in steps] if len(steps) > 1 else steps[0].llm_dict()
         return LLMOutput(role="assistant", content=json.dumps(content, indent=2, ensure_ascii=False))
 

--- a/tapeagents/nodes.py
+++ b/tapeagents/nodes.py
@@ -6,15 +6,15 @@ from pydantic import Field, TypeAdapter, ValidationError
 
 from .agent import Node
 from .core import (
-    LLMOutputParsingFailureAction,
     AgentStep,
-    StepMetadata,
     LLMOutput,
+    LLMOutputParsingFailureAction,
     Observation,
     PartialStep,
     Prompt,
     SetNextNode,
     Step,
+    StepMetadata,
     StopStep,
     Tape,
 )
@@ -94,14 +94,14 @@ class MonoNode(Node):
     def postprocess_step(self, tape: Tape, new_steps: list[Step], step: Step) -> Step:
         return step
 
-    def parse_completion(self, completion: str, prompt_id: str) -> Generator[Step, None, None]:
+    def parse_completion(self, llm_output: str, prompt_id: str) -> Generator[Step, None, None]:
         try:
-            step_dicts = json.loads(sanitize_json_completion(completion))
+            step_dicts = json.loads(sanitize_json_completion(llm_output))
             if isinstance(step_dicts, dict):
                 step_dicts = [step_dicts]
         except Exception as e:
-            logger.exception(f"Failed to parse agent output: {completion}\n\nError: {e}")
-            yield LLMOutputParsingFailureAction(error=f"Failed to parse agent output: {completion}\n\nError: {e}")
+            logger.exception(f"Failed to parse LLM output as json: {llm_output}\n\nError: {e}")
+            yield LLMOutputParsingFailureAction(error=f"Failed to parse LLM output as json: {e}", llm_output=llm_output)
             return
         try:
             steps = [TypeAdapter(self.agent_step_cls).validate_python(step_dict) for step_dict in step_dicts]
@@ -110,17 +110,14 @@ class MonoNode(Node):
             for err in e.errors():
                 loc = ".".join([str(loc) for loc in err["loc"]])
                 err_text += f"{loc}: {err['msg']}\n"
-            logger.exception(f"Failed to validate agent output: {step_dicts}\n\nErrors:\n{err_text}")
+            logger.exception(f"Failed to validate LLM output: {step_dicts}\n\nErrors:\n{err_text}")
             yield LLMOutputParsingFailureAction(
-                error=f"Failed to validate agent output: {step_dicts}\n\nErrors:\n{err_text}",
-                metadata=StepMetadata(other={"completion": completion}),
+                error=f"Failed to validate LLM output: {err_text}", llm_output=llm_output
             )
             return
         except Exception as e:
-            logger.exception(f"Failed to parse agent output dict: {step_dicts}\n\nError: {e}")
-            yield LLMOutputParsingFailureAction(
-                error=f"Failed to parse agent output dict: {step_dicts}\n\nError: {e}"
-            )
+            logger.exception(f"Failed to parse LLM output dict: {step_dicts}\n\nError: {e}")
+            yield LLMOutputParsingFailureAction(error=f"Failed to parse LLM output dict: {e}", llm_output=llm_output)
             return
         for step in steps:
             step.metadata.prompt_id = prompt_id


### PR DESCRIPTION
- Update `LLMOutputParsingFailureAction` step to store the full llm output that was the reason of failure.
- Use it during tape reuse to generate corresponding training sample completion
- Small environment module cleanup
- update completion generation for cases with the steps not from llm output