### PR TITLE
Browse math tapes

### DIFF
--- a/examples/rl_gsm8k/browse.py
+++ b/examples/rl_gsm8k/browse.py
@@ -1,0 +1,9 @@
+import logging
+logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+
+from tapeagents.rendering import PrettyRenderer
+from tapeagents.tape_browser import TapeBrowser
+from examples.gsm8k_tuning.math_agent import MathTape
+
+
+TapeBrowser(MathTape, "outputs/rl_debug_v6/tapes/train", PrettyRenderer(), file_extension=".json").launch()

--- a/examples/rl_gsm8k/browse.py
+++ b/examples/rl_gsm8k/browse.py
@@ -1,9 +1,19 @@
-import logging
-logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+import os
+from pathlib import Path
+import sys
 
-from tapeagents.rendering import PrettyRenderer
+from tapeagents.renderers.camera_ready_renderer import CameraReadyRenderer
 from tapeagents.tape_browser import TapeBrowser
 from examples.gsm8k_tuning.math_agent import MathTape
 
+# comment this code out if loading the prompt and completions takes too long for you
+tape_dir = Path(sys.argv[1])
+exp_dir = tape_dir
+# try to find a parent directory for tape_dir path that contains llm_calls.sqlite
+while not os.path.exists(exp_dir / "llm_calls.sqlite") and exp_dir != Path("."):
+    exp_dir = exp_dir.parent
+os.environ["TAPEAGENTS_SQLITE_DB"] = os.path.join(exp_dir, "llm_calls.sqlite")
 
-TapeBrowser(MathTape, "outputs/rl_debug_v6/tapes/train", PrettyRenderer(), file_extension=".json").launch()
+
+browser = TapeBrowser(MathTape, sys.argv[1], CameraReadyRenderer(), file_extension=".json")
+browser.launch(port=7680 if len(sys.argv) < 3 else int(sys.argv[2]))

--- a/examples/rl_gsm8k/gather_jsons.py
+++ b/examples/rl_gsm8k/gather_jsons.py
@@ -1,0 +1,20 @@
+# read json files from a folder, create new json with the same name that contains all the content
+
+import json
+import os
+from pathlib import Path
+
+def gather_jsons(folder: str):
+    all_jsons = []
+    for root, _, files in os.walk(folder):
+        for file in files:
+            if file.endswith(".json"):
+                with open(os.path.join(root, file)) as f:
+                    all_jsons.append(json.load(f))
+    
+    dst_name = f"{folder}.json"
+    with open(dst_name, "w") as f:
+        json.dump(all_jsons, f, indent=4)
+
+
+gather_jsons("outputs/rl_debug_v6/tapes/train/0")

--- a/examples/rl_gsm8k/gather_jsons.py
+++ b/examples/rl_gsm8k/gather_jsons.py
@@ -1,8 +1,11 @@
 # read json files from a folder, create new json with the same name that contains all the content
 
+import sys
 import json
 import os
-from pathlib import Path
+
+from tapeagents.io import load_tapes
+from examples.gsm8k_tuning.math_agent import MathTape
 
 def gather_jsons(folder: str):
     all_jsons = []
@@ -12,9 +15,11 @@ def gather_jsons(folder: str):
                 with open(os.path.join(root, file)) as f:
                     all_jsons.append(json.load(f))
     
-    dst_name = f"{folder}.json"
+    dst_dir = f"{folder}/all"
+    os.makedirs(dst_dir, exist_ok=True)
+    dst_name = f"{dst_dir}/tapes.json"
     with open(dst_name, "w") as f:
         json.dump(all_jsons, f, indent=4)
 
 
-gather_jsons("outputs/rl_debug_v6/tapes/train/0")
+gather_jsons(sys.argv[1])

--- a/examples/rl_gsm8k/orchestrate_rl.py
+++ b/examples/rl_gsm8k/orchestrate_rl.py
@@ -297,9 +297,6 @@ def main(cfg: DictConfig):
             use_cache=False,
         )
 
-        tapes_dir = exp_path / "tapes" / str(state["iteration"])
-        os.makedirs(tapes_dir, exist_ok=True)
-
         try:
             sub_samples = random.sample(train_samples, cfg.max_agent_forks // cfg.attempts)
             train_tapes = convert_samples_to_tapes(sub_samples)

--- a/tapeagents/observe.py
+++ b/tapeagents/observe.py
@@ -15,7 +15,7 @@ from .core import LLMCall, LLMOutput, Prompt, Tape
 logger = logging.getLogger(__name__)
 
 _checked_sqlite = False
-_ACTIVE_MANAGER: Optional["SQLiteQueueManager"] = None
+_ACTIVE_MANAGER: Optional["SQLiteWriterThread"] = None
 
 LLMCallListener = Callable[[LLMCall], None]
 TapeListener = Callable[[Tape], None]
@@ -249,7 +249,7 @@ def retrieve_all_llm_calls(sqlite_fpath: str | None = None) -> list[LLMCall]:
     return calls
 
 
-class SQLiteQueueManager:
+class SQLiteWriterThread:
     def __init__(self):
         self.write_queue: Optional[queue.Queue] = None
         self.writer_thread: Optional[threading.Thread] = None

--- a/tapeagents/observe.py
+++ b/tapeagents/observe.py
@@ -169,14 +169,15 @@ def observe_tape(tape: Tape):
 
 
 def retrieve_tape_llm_calls(tapes: Tape | list[Tape]) -> dict[str, LLMCall]:
+    logger.info(f"Retrieving LLM calls")
     if isinstance(tapes, Tape):
         tapes = [tapes]
     result = {}
-    for tape in tapes:
-        for step in tape:
-            if prompt_id := step.metadata.prompt_id:
-                if call := retrieve_llm_call(prompt_id):
-                    result[prompt_id] = call
+    prompt_ids = set([step.metadata.prompt_id for tape in tapes for step in tape if step.metadata.prompt_id])
+    for prompt_id in prompt_ids:
+        if call := retrieve_llm_call(prompt_id):
+            result[prompt_id] = call
+    logger.info(f"Retrieved {len(result)} LLM calls")
     return result
 
 

--- a/tapeagents/tape_browser.py
+++ b/tapeagents/tape_browser.py
@@ -223,4 +223,4 @@ class TapeBrowser:
             app = gr.mount_gradio_app(app, blocks, path="/")
             uvicorn.run(app, host=server_name, port=port)
         else:
-            blocks.launch(server_name=server_name, debug=debug)
+            blocks.launch(server_name=server_name, server_port=port, debug=debug)

--- a/tapeagents/tape_browser.py
+++ b/tapeagents/tape_browser.py
@@ -54,7 +54,9 @@ class TapeBrowser:
         return tapes
 
     def load_llm_calls(self):
+        logger.info("Loading LLM calls")
         self.llm_calls = retrieve_tape_llm_calls(self.tapes)
+        logger.info(f"Loaded {len(self.llm_calls)} LLM calls")
 
     def get_steps(self, tape: Tape) -> list:
         return tape.steps


### PR DESCRIPTION
- add a script to launch the tape browser
- save tapes in a single json file, which is a format that the default tape browser can load
- add a script to gather legacy tapes in single file so that we can view legacy tapes in the browser
- load LLM Calls 100 at a time to speed up tape browser loading time (the speedup was huge when the browser did not know where to look for LLM Calls; now that I added the search for `llm_calls.sqlite` to `browser.py`, loading is taking some time again)

Examples:
- gather legacy jsons like this: `python examples/rl_gsm8k/gather_jsons.py outputs/yolo2_4gpu_lr1e-6/tapes/train/1`
- run tape browser like this: `python -m examples.rl_gsm8k.browse outputs/yolo2_4gpu_lr1e-6/tapes/train/0/all`
