### PR TITLE
run code from llm with timeout

### DIFF
--- a/examples/gaia_agent/scripts/tape_browser.py
+++ b/examples/gaia_agent/scripts/tape_browser.py
@@ -98,17 +98,17 @@ class GaiaTapeBrowser(TapeBrowser):
         return html
 
     def get_tape_name(self, i: int, tape: GaiaTape) -> str:
-        error = "F" if tape.metadata.error else None
+        error = "F" if tape.metadata.error else ""
         last_action = None
         for step in tape:
             if isinstance(step, Action):
                 last_action = step
             if step.kind == "page_observation" and step.error:
-                error = "br"
+                error += "br"
             elif step.kind == "llm_output_parsing_failure_action":
-                error = "pa"
+                error += "pa"
             elif step.kind == "action_execution_failure" and last_action:
-                error = last_action.kind[:2]
+                error += last_action.kind[:2]
         mark = "+" if tape_correct(tape) else ("" if tape.metadata.result else "∅")
         if tape.metadata.task["file_name"]:
             ext = tape.metadata.task["file_name"].split(".")[-1]

--- a/tapeagents/tools/document_converters.py
+++ b/tapeagents/tools/document_converters.py
@@ -454,11 +454,10 @@ class WavConverter(DocumentConverter):
             return None
 
         model = whisper.load_model("turbo")
-        text_content = model.transcribe(local_path)
-
+        text_content = model.transcribe(local_path) or "[No speech detected]"
         return DocumentConverterResult(
             title=None,
-            text_content="### Audio Transcript:\n" + ("[No speech detected]" if text_content == "" else text_content),
+            text_content=f"### Audio Transcript:\n{text_content}",
         )
 
 

--- a/tapeagents/tools/media_reader.py
+++ b/tapeagents/tools/media_reader.py
@@ -206,7 +206,12 @@ def generate_contact_sheets_from_video(
     frames_per_interval = int(fps * frame_interval_seconds)
 
     # Generate contact sheets
-    vf = """drawtext=text='%{pts\\:hms}'
+    font = os.environ.get("FFMPEG_FONT")
+    if font:
+        vf = f"drawtext=text='%{{pts\\:hms}}:fontfile={font}"
+    else:
+        vf = "drawtext=text='%{pts\\:hms}"
+    vf += """
             :x='(main_w-text_w)/2'
             :y='(main_h-text_h)'
             :fontcolor='Yellow'


### PR DESCRIPTION
1. add timeout in case of running code in the restricted python interpreter, when the podman is not available.
2. optional font passing to ffmpeg converter as it can fail if cannot find default one
3. fix audio converter formatting error when empty ouput
4. better error labels in tape browser