### PR TITLE
Less overhead batch tapeagents

### DIFF
--- a/conf/rl_gsm8k.yaml
+++ b/conf/rl_gsm8k.yaml
@@ -43,6 +43,7 @@ vllm_config:
     --disable-log-requests: ""
     --max-num-seqs: 1024 
     --enforce-eager: ""
+    --return-tokens-as-token-ids: ""
   actor_vllm_kwargs:
     --num-scheduler-steps: 16
   ref_vllm_kwargs:

--- a/examples/rl_gsm8k/orchestrate_rl.py
+++ b/examples/rl_gsm8k/orchestrate_rl.py
@@ -349,7 +349,7 @@ def main(cfg: DictConfig):
 
                 test_llms = [
                     TrainableLLM(
-                        base_url=vllm_service_manager.get_base_urls(),
+                        base_url=base_url,
                         model_name=str(assistant_model_path),
                         tokenizer_name=str(assistant_model_path),
                         parameters=cfg.test_llm.parameters,

--- a/examples/rl_gsm8k/orchestrate_rl.py
+++ b/examples/rl_gsm8k/orchestrate_rl.py
@@ -1,5 +1,4 @@
 import copy
-from itertools import chain
 import json
 import logging
 import multiprocessing
@@ -8,7 +7,7 @@ import random
 import time
 from collections import defaultdict
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
-from functools import partial
+from itertools import chain
 from pathlib import Path
 from typing import Dict, List, Tuple
 
@@ -21,8 +20,10 @@ from termcolor import colored
 from tqdm import tqdm
 
 import wandb
-
 from tapeagents.agent import Agent
+from tapeagents.core import LLMOutputParsingFailureAction, StepMetadata, TrainingText
+from tapeagents.finetune.logging_ import flatten_dict_config, init_wandb
+from tapeagents.llms import TrainableLLM
 
 from .cot_math_agent import (
     CoTMathAgent,
@@ -36,18 +37,11 @@ from .utils import (
     VLLMServiceManager,
     calculate_stats,
     clean_up,
-    get_tokens_from_hf_tokenizer,
     launch_training,
     load_state,
     save_state,
     setup_logging,
 )
-from tapeagents.batch import batch_main_loop
-from tapeagents.core import LLMOutputParsingFailureAction, StepMetadata, TrainingText
-from tapeagents.finetune.logging_ import flatten_dict_config, init_wandb
-from tapeagents.llms import TrainableLLM
-from tapeagents.observe import LLMCall, SQLiteWriterThread, retrieve_all_llm_calls
-from tapeagents.orchestrator import main_loop
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +53,7 @@ def annotate_traces_with_ref_logprobs(agent: CoTMathAgent, trace: TrainingText, 
             trace.input_ids[-len(trace.logprobs) :],
         )
         ref_logprobs = agent.llm.get_logprobs(prompt_token_ids, completion_token_ids)  # type: ignore
-        trace.ref_logprobs = [c['logprob'] for c in ref_logprobs["content"]]
+        trace.ref_logprobs = [c["logprob"] for c in ref_logprobs["content"]]
         assert len(trace.ref_logprobs) == len(trace.logprobs), f"{len(trace.ref_logprobs)} != {len(trace.logprobs)}"
         return trace
     except Exception as e:
@@ -233,7 +227,7 @@ def generate_training_data(
 
     start_making_tapes = time.time()
     with ProcessPoolExecutor(max_workers=len(agent_replicas)) as executor:
-        replica_tapes = [tapes[i::len(agent_replicas)] for i in range(len(agent_replicas))]
+        replica_tapes = [tapes[i :: len(agent_replicas)] for i in range(len(agent_replicas))]
         results = list(executor.map(batch_run_agent_replica, agent_replicas, replica_tapes))
         final_tapes = list(chain(*[r[1] for r in results]))
         agent_replicas = [r[0] for r in results]
@@ -378,7 +372,10 @@ def main(cfg: DictConfig):
                     throughput_stats = {
                         "prompt_tokens_per_sec": stats[f"{split_name}_prompt_tokens"] / make_data_took,
                         "output_tokens_per_sec": stats[f"{split_name}_output_tokens"] / make_data_took,
-                        "total_tokens_per_sec": (stats[f"{split_name}_prompt_tokens"] + stats[f"{split_name}_output_tokens"]) / make_data_took,
+                        "total_tokens_per_sec": (
+                            stats[f"{split_name}_prompt_tokens"] + stats[f"{split_name}_output_tokens"]
+                        )
+                        / make_data_took,
                     }
                     stats.update(llm_stats)
                     stats.update(throughput_stats)
@@ -420,7 +417,7 @@ def main(cfg: DictConfig):
                 verbose=True,
                 gpus_per_model_instance=cfg.gpus_per_model_instance,
                 cuda_device=",".join([str(i) for i in range(torch.cuda.device_count())]),
-                **(dict(cfg.vllm_config.vllm_kwargs) | dict(cfg.vllm_config.ref_vllm_kwargs))
+                **(dict(cfg.vllm_config.vllm_kwargs) | dict(cfg.vllm_config.ref_vllm_kwargs)),
             ) as vllm_service_manager:
                 basemodel_llm = TrainableLLM(
                     base_url=vllm_service_manager.get_base_urls(),

--- a/examples/rl_gsm8k/utils.py
+++ b/examples/rl_gsm8k/utils.py
@@ -155,6 +155,7 @@ class VLLMServiceManager:
             f"--model {self.model_name_or_path} "
             f"--tensor-parallel-size {tensor_parallel_size} "
             f"--port {port} "
+            "--return-tokens-as-token-ids "
             "--disable-frontend-multiprocessing "
             "--dtype bfloat16 "
             f"{kwargs_str}"

--- a/examples/rl_gsm8k/utils.py
+++ b/examples/rl_gsm8k/utils.py
@@ -216,11 +216,13 @@ class VLLMServiceManager:
             f.close()
 
     def __enter__(self) -> "VLLMServiceManager":
-        self._start_service()
+        #self._start_service()
+        self.ports = [8080, 8081]
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
-        self._cleanup()
+        return None
+        #self._cleanup()
 
     def get_stats(self):
         return self.stats

--- a/examples/rl_gsm8k/utils.py
+++ b/examples/rl_gsm8k/utils.py
@@ -155,7 +155,7 @@ class VLLMServiceManager:
             f"--model {self.model_name_or_path} "
             f"--tensor-parallel-size {tensor_parallel_size} "
             f"--port {port} "
-            "--return-tokens-as-token-ids "
+            f"--seed {cuda_device} "
             "--disable-frontend-multiprocessing "
             "--dtype bfloat16 "
             f"{kwargs_str}"
@@ -216,13 +216,11 @@ class VLLMServiceManager:
             f.close()
 
     def __enter__(self) -> "VLLMServiceManager":
-        #self._start_service()
-        self.ports = [8080, 8081]
+        self._start_service()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
-        return None
-        #self._cleanup()
+        self._cleanup()
 
     def get_stats(self):
         return self.stats

--- a/tapeagents/agent.py
+++ b/tapeagents/agent.py
@@ -711,6 +711,7 @@ class Agent(BaseModel, Generic[TapeType]):
         if not isinstance(self.llm, TrainableLLM):
             raise NotImplementedError("For run_agent_batch the LLM must be TrainableLLM")
         original_tapes = list(tapes)
+        parent_ids = [tape.metadata.id for tape in tapes]
         n_iterations = 0
         active_indices = set(range(len(tapes)))
         while n_iterations < self.max_iterations:
@@ -736,7 +737,7 @@ class Agent(BaseModel, Generic[TapeType]):
             n_iterations += 1
         for i in range(len(tapes)):
             updated_metadata = original_tapes[i].metadata.model_validate(dict(
-                parent_id=original_tapes[i].metadata.id,
+                parent_id=parent_ids[i],
                 author=self.name,
                 n_added_steps=len(tapes[i]) - len(original_tapes[i])
             ))

--- a/tapeagents/agent.py
+++ b/tapeagents/agent.py
@@ -711,7 +711,6 @@ class Agent(BaseModel, Generic[TapeType]):
         if not isinstance(self.llm, TrainableLLM):
             raise NotImplementedError("For run_agent_batch the LLM must be TrainableLLM")
         original_tapes = list(tapes)
-        parent_ids = [tape.metadata.id for tape in tapes]
         n_iterations = 0
         active_indices = set(range(len(tapes)))
         while n_iterations < self.max_iterations:
@@ -737,7 +736,7 @@ class Agent(BaseModel, Generic[TapeType]):
             n_iterations += 1
         for i in range(len(tapes)):
             updated_metadata = original_tapes[i].metadata.model_validate(dict(
-                parent_id=parent_ids[i],
+                parent_id=original_tapes[i].metadata.id,
                 author=self.name,
                 n_added_steps=len(tapes[i]) - len(original_tapes[i])
             ))

--- a/tapeagents/core.py
+++ b/tapeagents/core.py
@@ -355,7 +355,6 @@ LLMOutput: TypeAlias = litellm.utils.Message
 
 class TokenLogprob(BaseModel):
     logprob: float
-    token: str
     token_id: int
     generated: int
 

--- a/tapeagents/llms.py
+++ b/tapeagents/llms.py
@@ -627,6 +627,7 @@ class TrainableLLM(CachedLLM):
                     )
                     # prompt_decoded = self.tokenizer.decode(prompt_token_ids, skip_special_tokens=False)
                     completion_logprobs = data["choices"][0]["logprobs"]["content"]
+                    # TODO: fix to use the token_ids
                     logprobs = self.make_llm_call_logprobs(prompt_token_ids, completion_logprobs)
                     # <end_of_turn> is the end of message for Gemma2B, eos_token is wrong for this model
                     for eos_str in [self.tokenizer.eos_token, "<end_of_turn>"]:

--- a/tapeagents/llms.py
+++ b/tapeagents/llms.py
@@ -680,8 +680,7 @@ class TrainableLLM(CachedLLM):
             stream=self.stream,
             verify=False,
         )
-        time_send_request = time.time() - start_send_request
-        self._stats["time_send_request"].append(time_send_request)
+        self._stats["time_send_request"].append(time.time() - start_send_request)
         if not r.ok:
             logger.error(f"Failed to get completion: {r.text}")
             r.raise_for_status()

--- a/tapeagents/llms.py
+++ b/tapeagents/llms.py
@@ -700,7 +700,8 @@ class TrainableLLM(CachedLLM):
                     # Before calling self.process_logprobs, we need to convert the logprobs to a
                     # list of dicts format similar to /v1/chat/completions
                     
-                    #'tokens': ['token_id:1271', 'token_id:1505', '
+                    # We assume that the server was launched with --return-tokens-as-token-ids
+                    # and that the tokens are provided as: ['token_id:1271', 'token_id:1505', '
                     chat_completion_logprobs = [
                         {"token_id": int(completion_logprobs["tokens"][j].split(":")[-1]), "logprob": completion_logprobs["token_logprobs"][j]}
                         for j in range(len(completion_logprobs["tokens"]))

--- a/tapeagents/llms.py
+++ b/tapeagents/llms.py
@@ -261,7 +261,7 @@ class LLM(BaseModel, ABC):
             "total_output_tokens": np.sum(self._stats["output_length_tokens"])
             if self._stats["output_length_tokens"]
             else 0,
-            "time_preprocess": np.mean(self._stats["time_preprocess"]) if self._stats["time_preprocess"] else 0,
+            "time_postprocess_llm_response": np.mean(self._stats["time_postprocess_llm_response"]) if self._stats["time_postprocess_llm_response"] else 0,
         }
 
 
@@ -686,7 +686,7 @@ class TrainableLLM(CachedLLM):
             r.raise_for_status()
         data = r.json()
         result = []
-        start_preprocess_time = time.time()
+        start_postprocess_time = time.time()
         for i in range(len(prompts)):
             try:
                 content = data["choices"][i]["text"]
@@ -720,8 +720,7 @@ class TrainableLLM(CachedLLM):
             llm_call = self.log_output(prompts[i], output)
             llm_call.logprobs = logprobs
             result.append(llm_call)
-        end_preprocess_time = time.time()
-        self._stats["time_preprocess"].append(end_preprocess_time - start_preprocess_time)
+        self._stats["time_postprocess_llm_response"].append(time.time() - start_postprocess_time)
         return result
 
     def load_tokenizer(self):

--- a/tapeagents/llms.py
+++ b/tapeagents/llms.py
@@ -551,9 +551,11 @@ class TrainableLLM(CachedLLM):
         for logprob in completion_logprobs:
             if logprob:
                 try:
+                    # We assume that the server was launched with --return-tokens-as-token-ids
+                    # and that the tokens are provided as: ['token_id:1271', 'token_id:1505', '
                     logprobs.append(
                         TokenLogprob(
-                            token_id=logprob["token_id"],
+                            token_id=int(logprob["token"].split(":")[-1]),
                             logprob=logprob["logprob"],
                             generated=1,
                         )
@@ -566,6 +568,7 @@ class TrainableLLM(CachedLLM):
 
     @retry(stop=stop_after_attempt(5), wait=wait_exponential(multiplier=1, min=2))
     def _generate(self, prompt: Prompt) -> Generator[LLMEvent, None, None]:
+        self.load_tokenizer()
         headers = {"Content-Type": "application/json"}
         if self.api_token:
             headers |= {"Authorization": f"Bearer {self.api_token}"}
@@ -627,7 +630,6 @@ class TrainableLLM(CachedLLM):
                     )
                     # prompt_decoded = self.tokenizer.decode(prompt_token_ids, skip_special_tokens=False)
                     completion_logprobs = data["choices"][0]["logprobs"]["content"]
-                    # TODO: fix to use the token_ids
                     logprobs = self.make_llm_call_logprobs(prompt_token_ids, completion_logprobs)
                     # <end_of_turn> is the end of message for Gemma2B, eos_token is wrong for this model
                     for eos_str in [self.tokenizer.eos_token, "<end_of_turn>"]:
@@ -700,10 +702,8 @@ class TrainableLLM(CachedLLM):
                     # Before calling self.process_logprobs, we need to convert the logprobs to a
                     # list of dicts format similar to /v1/chat/completions
                     
-                    # We assume that the server was launched with --return-tokens-as-token-ids
-                    # and that the tokens are provided as: ['token_id:1271', 'token_id:1505', '
                     chat_completion_logprobs = [
-                        {"token_id": int(completion_logprobs["tokens"][j].split(":")[-1]), "logprob": completion_logprobs["token_logprobs"][j]}
+                        {"token": completion_logprobs["tokens"][j], "logprob": completion_logprobs["token_logprobs"][j]}
                         for j in range(len(completion_logprobs["tokens"]))
                     ]
                     logprobs = self.make_llm_call_logprobs(prompt_token_ids[i], chat_completion_logprobs)

--- a/tapeagents/llms.py
+++ b/tapeagents/llms.py
@@ -111,12 +111,12 @@ class LLMStream:
         if not o.role == "assistant" or o.content is None:
             raise ValueError("LLM did not produce an assistant message")
         return o.content
-    
+
     def get_llm_call(self) -> LLMCall:
         """Returns the LLMCall object"""
         for event in self:
             if event.llm_call:
-                break 
+                break
         return self.llm_call
 
 
@@ -261,6 +261,7 @@ class LLM(BaseModel, ABC):
             "total_output_tokens": np.sum(self._stats["output_length_tokens"])
             if self._stats["output_length_tokens"]
             else 0,
+            "time_preprocess": np.mean(self._stats["time_preprocess"]) if self._stats["time_preprocess"] else 0,
         }
 
 
@@ -534,16 +535,20 @@ class TrainableLLM(CachedLLM):
         super().model_post_init(__context)
         self.api_token = os.getenv(TAPEAGENTS_LLM_TOKEN, "")
 
-    def make_llm_call_logprobs(self, prompt_token_ids: list[int], completion_logprobs: list[dict]) -> list[TokenLogprob]:
+    def make_llm_call_logprobs(
+        self, prompt_token_ids: list[int], completion_logprobs: list[dict]
+    ) -> list[TokenLogprob]:
         """Construct homogenous list of TokenLogprob's for prompt and completion tokens"""
         logprobs = []
         for id in prompt_token_ids:
-            logprobs.append(TokenLogprob(
-                token_id=id,
-                token=self.tokenizer.decode([id]),
-                logprob=0.,
-                generated=0,
-            ))
+            logprobs.append(
+                TokenLogprob(
+                    token_id=id,
+                    token=self.tokenizer.decode([id]),
+                    logprob=0.0,
+                    generated=0,
+                )
+            )
         for logprob in completion_logprobs:
             if logprob:
                 try:
@@ -552,12 +557,14 @@ class TrainableLLM(CachedLLM):
                         # TODO: how should we handle empty tokens?
                         logger.debug(f"Empty token: {logprob}")
                         continue
-                    logprobs.append(TokenLogprob(
-                        token_id=token_id[0],
-                        token=logprob["token"],
-                        logprob=logprob["logprob"],
-                        generated=1,
-                    ))
+                    logprobs.append(
+                        TokenLogprob(
+                            token_id=token_id[0],
+                            token=logprob["token"],
+                            logprob=logprob["logprob"],
+                            generated=1,
+                        )
+                    )
                 except Exception as e:
                     logger.error(f"Failed to process logprobs: {logprob}")
                     logger.error(e)
@@ -653,7 +660,7 @@ class TrainableLLM(CachedLLM):
             headers |= {"Authorization": f"Bearer {self.api_token}"}
 
         prompt_token_ids = [
-            self.tokenizer.apply_chat_template(p.messages, add_special_tokens=True, add_generation_prompt=True) 
+            self.tokenizer.apply_chat_template(p.messages, add_special_tokens=True, add_generation_prompt=True)
             for p in prompts
         ]
         data = {
@@ -685,7 +692,8 @@ class TrainableLLM(CachedLLM):
             logger.error(f"Failed to get completion: {r.text}")
             r.raise_for_status()
         data = r.json()
-        result = [] 
+        result = []
+        start_preprocess_time = time.time()
         for i in range(len(prompts)):
             try:
                 content = data["choices"][i]["text"]
@@ -696,14 +704,11 @@ class TrainableLLM(CachedLLM):
                 if self.collect_logprobs:
                     completion_logprobs = data["choices"][i]["logprobs"]
                     # /v1/completions returns logprobs in a format different to /v1/chat/completions
-                    # Before calling self.process_logprobs, we need to convert the logprobs to a 
+                    # Before calling self.process_logprobs, we need to convert the logprobs to a
                     # list of dicts format similar to /v1/chat/completions
                     chat_completion_logprobs = [
-                        {
-                            "token": completion_logprobs["tokens"][i], 
-                            "logprob": completion_logprobs["token_logprobs"][i]
-                        }
-                        for i in range(len(completion_logprobs["tokens"]))
+                        {"token": completion_logprobs["tokens"][j], "logprob": completion_logprobs["token_logprobs"][j]}
+                        for j in range(len(completion_logprobs["tokens"]))
                     ]
                     logprobs = self.make_llm_call_logprobs(prompt_token_ids[i], chat_completion_logprobs)
                     # <end_of_turn> is the end of message for Gemma2B, eos_token is wrong for this model
@@ -719,6 +724,8 @@ class TrainableLLM(CachedLLM):
             llm_call = self.log_output(prompts[i], output)
             llm_call.logprobs = logprobs
             result.append(llm_call)
+        end_preprocess_time = time.time()
+        self._stats["time_preprocess"].append(end_preprocess_time - start_preprocess_time)
         return result
 
     def load_tokenizer(self):


### PR DESCRIPTION
- [x] Collecting log probs is now faster in `batch_generate`, since we do not need to tokenize/detokenize every token_id/token.
- [x] Need to do the same for generate
- [x] Fix the vllm seed initialization. 