### PR TITLE
produce use step outside of the agent

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "TapeAgents"
-version = "0.1.6"
+version = "0.1.7"
 requires-python = ">= 3.10, <3.13"
 description = "TapeAgents framework for building, tuning and evaluating LLM Agents"
 authors = [

--- a/tapeagents/nodes.py
+++ b/tapeagents/nodes.py
@@ -273,7 +273,6 @@ class StandardNode(Node):
                 yield self.postprocess_step(tape, new_steps[:i], step)
                 if isinstance(step, LLMOutputParsingFailureAction):
                     yield SetNextNode(next_node=self.name)  # loop to the same node to retry
-                    yield UserStep(content="Try again")
                     break
         if not new_steps:
             raise FatalError("No completions!")


### PR DESCRIPTION
Fix after #195

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the logic in `environment.py` to introduce a `UserStep` return within the `step` method for failed LLM parsing actions and remove redundant `UserStep` occurrence after retry instruction in `nodes.py`; also bump the version to 0.1.7 in `pyproject.toml`.

### Why are these changes being made?

The change consolidates the `UserStep` logic into the `step` method, which simplifies the handling of `LLMOutputParsingFailureAction` by ensuring a consistent response to such errors, preventing redundancy, and reducing unnecessary complexity in the flow. The version bump reflects these functional improvements.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->