### PR TITLE
Handle running both MCP and TapeAgent tools

### DIFF
--- a/conf/environment/web_mcp.yaml
+++ b/conf/environment/web_mcp.yaml
@@ -1,2 +1,9 @@
 _target_: tapeagents.mcp.MCPEnvironment
 config_path: conf/mcp/web_and_code.json
+tools:
+  - _target_: tapeagents.tools.media_reader.VideoReader
+    exp_path: ${exp_path}
+  - _target_: tapeagents.tools.simple_browser.SimpleBrowser
+    exp_path: ${exp_path}
+    kwargs:
+      use_web_cache: true

--- a/tapeagents/environment.py
+++ b/tapeagents/environment.py
@@ -16,7 +16,7 @@ from tapeagents.agent import TapeType
 from tapeagents.core import Action, LLMOutputParsingFailureAction, Observation, Tape
 from tapeagents.dialog_tape import AssistantStep, DialogTape, UserStep
 from tapeagents.tool_calling import FunctionCall, ToolCalls, ToolResult, ToolSpec
-from tapeagents.tools.base import StatefulTool, Tool
+from tapeagents.tools.base import BaseTool as TapeAgentsBaseTool, StatefulTool, Tool
 from tapeagents.tools.container_executor import CodeBlock, CommandLineCodeResult, ContainerExecutor
 from tapeagents.utils import FatalError
 from tapeagents.view import defaultdict
@@ -158,13 +158,13 @@ class CodeExecutionEnvironment(Environment):
 
 
 class ToolCollectionEnvironment(Environment):
-    tools: list[Tool | StatefulTool]
+    tools: list[TapeAgentsBaseTool]
     loop_detection: bool = False
     loop_warning_after_n_steps: int = 3
     loop_warning: str = "You seem to be stuck producing the same action. Consider a new approach and avoid repeating previously attempted ineffective steps."
-    action_map: dict[type[Action], Tool | StatefulTool]
+    action_map: dict[type[Action], TapeAgentsBaseTool]
 
-    def __init__(self, tools: list[Tool | StatefulTool]) -> None:
+    def __init__(self, tools: list[TapeAgentsBaseTool]) -> None:
         super().__init__()
         self.tools = tools
         self.action_map = {tool.action: tool for tool in tools if isinstance(tool, Tool)}

--- a/tapeagents/environment.py
+++ b/tapeagents/environment.py
@@ -8,7 +8,7 @@ import time
 from abc import ABC, abstractmethod
 from typing import Callable, Generic, Literal
 
-from langchain_core.tools import BaseTool, tool as tool_wrapper
+from langchain_core.tools import BaseTool as LangchainBaseTool, tool as tool_wrapper
 from langchain_core.utils.function_calling import convert_to_openai_tool
 from pydantic import TypeAdapter
 
@@ -16,7 +16,7 @@ from tapeagents.agent import TapeType
 from tapeagents.core import Action, LLMOutputParsingFailureAction, Observation, Tape
 from tapeagents.dialog_tape import AssistantStep, DialogTape, UserStep
 from tapeagents.tool_calling import FunctionCall, ToolCalls, ToolResult, ToolSpec
-from tapeagents.tools.base import BaseTool as TapeAgentsBaseTool, StatefulTool, Tool
+from tapeagents.tools.base import BaseTool, StatefulTool, Tool
 from tapeagents.tools.container_executor import CodeBlock, CommandLineCodeResult, ContainerExecutor
 from tapeagents.utils import FatalError
 from tapeagents.view import defaultdict
@@ -82,8 +82,8 @@ class EmptyEnvironment(Environment):
 
 
 class ToolEnvironment(Environment):
-    def __init__(self, tools: list[BaseTool | Callable]):
-        self.tools: list[BaseTool] = [t if isinstance(t, BaseTool) else tool_wrapper(t) for t in tools]  # type: ignore
+    def __init__(self, tools: list[LangchainBaseTool | Callable]):
+        self.tools: list[LangchainBaseTool] = [t if isinstance(t, LangchainBaseTool) else tool_wrapper(t) for t in tools]  # type: ignore
         self._name2tool = {t.name: t for t in self.tools}
 
     def get_tool_schemas(self) -> list[ToolSpec]:
@@ -158,13 +158,13 @@ class CodeExecutionEnvironment(Environment):
 
 
 class ToolCollectionEnvironment(Environment):
-    tools: list[TapeAgentsBaseTool]
+    tools: list[BaseTool]
     loop_detection: bool = False
     loop_warning_after_n_steps: int = 3
     loop_warning: str = "You seem to be stuck producing the same action. Consider a new approach and avoid repeating previously attempted ineffective steps."
-    action_map: dict[type[Action], TapeAgentsBaseTool]
+    action_map: dict[type[Action], BaseTool]
 
-    def __init__(self, tools: list[TapeAgentsBaseTool]) -> None:
+    def __init__(self, tools: list[BaseTool]) -> None:
         super().__init__()
         self.tools = tools
         self.action_map = {tool.action: tool for tool in tools if isinstance(tool, Tool)}

--- a/tapeagents/mcp.py
+++ b/tapeagents/mcp.py
@@ -42,8 +42,7 @@ class MCPClient:
         logger.info(f"Started {len(self.servers)} MCP servers")
 
     def load_config(self, config_path) -> dict[str, StdioServerParameters]:
-        if not os.path.exists(config_path):
-            return {}
+        assert os.path.exists(config_path), f"Config path {config_path} does not exist"
         self.config_path = config_path
 
         try:

--- a/tapeagents/mcp.py
+++ b/tapeagents/mcp.py
@@ -4,15 +4,16 @@ import logging
 import os
 from contextlib import AsyncExitStack
 from datetime import timedelta
-from typing import Any
+from typing import Any, Optional
 
 import nest_asyncio
-from mcp import ClientSession, StdioServerParameters, Tool, stdio_client
+from mcp import ClientSession, StdioServerParameters, Tool as MCPTool, stdio_client
 from mcp.types import CallToolResult, TextContent
 
-from tapeagents.core import Action, LLMOutputParsingFailureAction
+from tapeagents.core import Action, LLMOutputParsingFailureAction, Observation
 from tapeagents.environment import ToolCollectionEnvironment
 from tapeagents.tool_calling import FunctionSpec, ToolCallAction, ToolResult, ToolSpec
+from tapeagents.tools.base import BaseTool
 
 nest_asyncio.apply()
 logger = logging.getLogger(__name__)
@@ -29,7 +30,7 @@ class MCPClient:
         self.servers = self.load_config(config_path)
         self.sessions: dict[str, ClientSession] = {}
         self.exit_stacks: dict[str, AsyncExitStack] = {}
-        self.tools: dict[str, Tool] = {}
+        self.tools: dict[str, MCPTool] = {}
         self.tool_to_server: dict[str, str] = {}
         self._cleanup_lock: asyncio.Lock = asyncio.Lock()
         asyncio.run(self.start_servers())
@@ -41,7 +42,8 @@ class MCPClient:
         logger.info(f"Started {len(self.servers)} MCP servers")
 
     def load_config(self, config_path) -> dict[str, StdioServerParameters]:
-        assert os.path.exists(config_path), f"Config path {config_path} does not exist"
+        if not os.path.exists(config_path):
+            return {}
         self.config_path = config_path
 
         try:
@@ -131,24 +133,31 @@ class MCPClient:
 
 class MCPEnvironment(ToolCollectionEnvironment):
     client: MCPClient
-    tools: dict[str, ToolSpec]
 
-    def __init__(self, config_path: str = "", client: MCPClient | None = None) -> None:
+    def __init__(
+        self, tools: Optional[list[BaseTool]] = None, config_path: str = "", client: MCPClient | None = None
+    ) -> None:
+        super().__init__(tools=tools or [])
         self.client = client or MCPClient(config_path)
-        self.tools = {
-            tool.name: ToolSpec(
-                function=FunctionSpec(name=tool.name, description=tool.description or "", parameters=tool.inputSchema)
-            )
-            for tool in self.client.tools.values()
-        }
+        self.tools.extend(
+            [
+                ToolSpec(
+                    function=FunctionSpec(
+                        name=tool.name, description=tool.description or "", parameters=tool.inputSchema
+                    )
+                )
+                for tool in self.client.tools.values()
+            ]
+        )
 
     def actions(self) -> tuple[type[Action] | ToolSpec, ...]:
-        return tuple(self.tools.values())
+        actions = super().actions()
+        tool_specs = [t for t in self.tools if isinstance(t, ToolSpec)]
+        return actions + tuple(tool_specs)
 
-    def tools_description(self) -> str:
-        return "\n".join(f"{spec.function.name} - {spec.function.description}" for spec in self.tools.values())
-
-    def step(self, action: ToolCallAction) -> ToolResult:
+    def step(self, action: Action) -> Observation:
+        if not isinstance(action, ToolCallAction):
+            return super().step(action)
         if isinstance(action, LLMOutputParsingFailureAction):
             return ToolResult(tool_call_id="", content="Try again")
         try:

--- a/tapeagents/tool_calling.py
+++ b/tapeagents/tool_calling.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel
 
 from tapeagents.core import Action, Observation, Step
 from tapeagents.llms import LLMOutput
+from tapeagents.tools.base import BaseTool
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +29,7 @@ class FunctionSpec(BaseModel):
     parameters: dict
 
 
-class ToolSpec(BaseModel):
+class ToolSpec(BaseTool):
     """
     ToolSpec is a model that represents a tool specification with a type and a function.
 
@@ -39,6 +40,12 @@ class ToolSpec(BaseModel):
 
     type: Literal["function"] = "function"
     function: FunctionSpec
+
+    def description(self) -> str:
+        return f"{self.function.name} - {self.function.description}"
+
+    def run(self, action: Action) -> Observation:
+        raise NotImplementedError("ToolSpec is not meant to be run directly.")
 
     @classmethod
     def from_function(cls, function: Callable):

--- a/tapeagents/tool_calling.py
+++ b/tapeagents/tool_calling.py
@@ -44,9 +44,6 @@ class ToolSpec(BaseTool):
     def description(self) -> str:
         return f"{self.function.name} - {self.function.description}"
 
-    def run(self, action: Action) -> Observation:
-        raise NotImplementedError("ToolSpec is not meant to be run directly.")
-
     @classmethod
     def from_function(cls, function: Callable):
         """

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -10,7 +10,8 @@ from tapeagents.dialog_tape import UserStep
 from tapeagents.llms import MockLLM
 from tapeagents.mcp import MCPClient, MCPEnvironment
 from tapeagents.nodes import StandardNode
-from tapeagents.tool_calling import FunctionCall, ToolCallAction, ToolResult
+from tapeagents.tool_calling import FunctionCall, ToolCallAction, ToolResult, ToolSpec
+from tapeagents.tools.calculator import Calculator, UseCalculatorAction
 
 MOCK_TOOLS = {
     "server1": [
@@ -68,6 +69,17 @@ class MockMCPClient(MCPClient):
             return CallToolResult(content=[TextContent(type="text", text=tool_args["message"])])
         else:
             raise Exception(f"Tool {tool_name} not implemented")
+
+def test_mcp_env_init():
+    env = MCPEnvironment(tools=[Calculator()], client=MockMCPClient("dummy_config.json"))
+
+    assert(len(env.tools) == 4)
+    assert sum(1 for tool in env.tools if isinstance(tool, Calculator)) == 1
+    assert sum(1 for tool in env.tools if isinstance(tool, ToolSpec)) == 3
+    actions = env.actions()
+    assert(len(actions) == 4)
+    assert sum(1 for action in actions if isinstance(action, ToolSpec)) == 3
+    assert sum(1 for action in actions if action == UseCalculatorAction) == 1
 
 
 def test_mcp_env():


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor to generalize tool handling by replacing specific `Tool` and `StatefulTool` types with `BaseTool` and update the system to support both MCP and TapeAgent tools.

### Why are these changes being made?

The change allows for a unified tool interface by abstracting tool operations using a `BaseTool` class, facilitating smoother integration and operation of tools from different systems (MCP and TapeAgent) within the environment. This improves maintainability and scalability by reducing the dependency on specific tool implementations while enabling both types of tools to coexist and operate efficiently within the framework.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->