### PR TITLE
Add tool result caching in MCPClient.call_tool()

### DIFF
--- a/tapeagents/tools/converters.py
+++ b/tapeagents/tools/converters.py
@@ -48,6 +48,7 @@ from youtube_transcript_api import YouTubeTranscriptApi
 
 logger = logging.getLogger(__name__)
 
+
 class DocumentConverterResult:
     """The result of converting a document to text."""
 
@@ -653,7 +654,6 @@ class ImageDoclingConverter(DoclingConverter):
         extension = kwargs.get("file_extension", "")
         if extension.lower() not in [".jpg", ".jpeg", ".png", ".tiff", ".bmp"]:
             return None
-        # TODO DT StandardPdfPipeline ?
         return super().convert(local_path, **kwargs)
 
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,5 +1,9 @@
+import asyncio
+import tempfile
 from typing import Any
+from unittest.mock import AsyncMock, patch
 
+import pytest
 from litellm import ChatCompletionMessageToolCall
 from mcp import Tool
 from mcp.types import CallToolResult, TextContent
@@ -45,9 +49,10 @@ MOCK_TOOLS = {
 
 
 class MockMCPClient(MCPClient):
-    def __init__(self, config_path: str):
+    def __init__(self, config_path: str, use_cache: bool = False) -> None:
         self.tools = {}
         self.tool_to_server = {}
+        self.use_cache = use_cache
 
         # Register mock tools
         for server_name, tools in MOCK_TOOLS.items():
@@ -55,7 +60,7 @@ class MockMCPClient(MCPClient):
                 self.tools[tool.name] = tool
                 self.tool_to_server[tool.name] = server_name
 
-    async def call_tool(self, tool_name: str, tool_args: dict[str, Any]) -> CallToolResult:
+    async def _call_tool(self, server_name: str, tool_name: str, tool_args: dict[str, Any]) -> CallToolResult:
         self.check_tool_exists(tool_name)
         # Simulate tool behavior
         if tool_name == "calculator":
@@ -70,14 +75,41 @@ class MockMCPClient(MCPClient):
         else:
             raise Exception(f"Tool {tool_name} not implemented")
 
+
+def mocked_common_cache_dir():
+    return tempfile.mkdtemp(prefix="test_cache_")
+
+
+@pytest.mark.parametrize("use_cache, expected_call_count", [(True, 1), (False, 2)])
+def test_mcp_client_cache_behavior(use_cache, expected_call_count):
+    with patch("tapeagents.tools.tool_cache.common_cache_dir", mocked_common_cache_dir):
+        client = MockMCPClient(config_path="dummy_config.json", use_cache=use_cache)
+        client._call_tool = AsyncMock(wraps=client._call_tool)
+
+        # Perform 2 calls with the same arguments
+        async def perform_calls():
+            result1 = await client.call_tool("calculator", {"operation": "add", "a": 1, "b": 2})
+            result2 = await client.call_tool("calculator", {"operation": "add", "a": 1, "b": 2})
+            assert isinstance(result1, CallToolResult)
+            assert result1.content[0].text == "3"
+            assert isinstance(result2, CallToolResult)
+            assert result2.content[0].text == "3"
+
+        asyncio.run(perform_calls())
+
+        # Verify _call_tool was called the expected number of times. Test has knowledge of internal implementation.
+        client._call_tool.assert_called_with("server1", "calculator", {"operation": "add", "a": 1, "b": 2})
+        assert client._call_tool.call_count == expected_call_count
+
+
 def test_mcp_env_init():
     env = MCPEnvironment(tools=[Calculator()], client=MockMCPClient("dummy_config.json"))
 
-    assert(len(env.tools) == 4)
+    assert len(env.tools) == 4
     assert sum(1 for tool in env.tools if isinstance(tool, Calculator)) == 1
     assert sum(1 for tool in env.tools if isinstance(tool, ToolSpec)) == 3
     actions = env.actions()
-    assert(len(actions) == 4)
+    assert len(actions) == 4
     assert sum(1 for action in actions if isinstance(action, ToolSpec)) == 3
     assert sum(1 for action in actions if action == UseCalculatorAction) == 1
 


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add caching mechanism for tool results in the `MCPClient.call_tool()` function to optionally store and retrieve results from the cache when `use_tool_cache` is set to True.

### Why are these changes being made?

These changes are being made to improve performance by reducing unnecessary re-execution of deterministic tool calls that do not alter state, allowing cached results to be reused. This caching strategy can reduce latency and computational overhead in environments where tool results can be reliably cached and reused. The implementation is particularly useful in scenarios where operations are repeated frequently with the same inputs.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->