### PR TITLE
Adjust `ExplainableAction`'s `reason_to_use` description

### DIFF
--- a/tapeagents/steps.py
+++ b/tapeagents/steps.py
@@ -16,7 +16,7 @@ REASON_TO_USE_KEY = "reason_to_use"
 
 class ExplainableAction(Action):
     reason_to_use: str = Field(
-        description="A summary of the reason we are using this tool written in the imperative form.", default=""
+        description="A summary of the reason you want to use this tool written in the form of 'I want to'", default=""
     )
 
 


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Adjust the `reason_to_use` description in `ExplainableAction` to clarify that it should be written in the form of "I want to".

### Why are these changes being made?
This change provides clearer guidance for users on how to frame their reasoning when using the tool, promoting consistency and ease of understanding. The updated phrasing aligns with first-person perspective usage, potentially enhancing the descriptiveness and personal connection to the actions being logged.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->