### PR TITLE
Tool DocumentReader supports `MarkdownConverter` and DocumentObservation include `source`

### DIFF
--- a/tapeagents/tools/document_reader.py
+++ b/tapeagents/tools/document_reader.py
@@ -31,6 +31,7 @@ def read_document(path: str, file_converter_options: Optional[FileConverterOptio
 class DocumentObservation(Observation):
     kind: Literal["document_observation"] = "document_observation"
     text: str
+    source: str
     error: str | None = None
 
 
@@ -62,14 +63,14 @@ class DocumentReader(Tool):
             try:
                 abs_path.relative_to(workspace_dir)
             except ValueError:
-                return DocumentObservation(text="", error="Access to files outside the workspace directory is not allowed")
+                return DocumentObservation(text="", source="", error="Access to files outside the workspace directory is not allowed")
             workspace_path = abs_path
         else:
             workspace_path = Path(action.path)
         if not workspace_path.exists():
-            return DocumentObservation(text="", error=f"File {action.path} not found in the workspace")
+            return DocumentObservation(text="", source="", error=f"File {action.path} not found in the workspace")
         text, error = read_document(str(workspace_path), self.file_converter_options)
-        return DocumentObservation(text=text, error=error)
+        return DocumentObservation(text=text, source=str(action.path), error=error)
 
 
 class ListLocalDocumentsAction(Action):

--- a/tapeagents/tools/document_reader.py
+++ b/tapeagents/tools/document_reader.py
@@ -31,7 +31,7 @@ def read_document(path: str, file_converter_options: Optional[FileConverterOptio
 class DocumentObservation(Observation):
     kind: Literal["document_observation"] = "document_observation"
     text: str
-    source: str
+    source: str | None = None # optional for tape backwards compatibility
     error: str | None = None
 
 
@@ -73,12 +73,12 @@ class DocumentReader(Tool):
         return DocumentObservation(text=text, source=str(action.path), error=error)
 
 
-class ListLocalDocumentsAction(Action):
+class ListDocumentsAction(Action):
     """
     Action that lists all documents in the workspace directory.
     """
 
-    kind: Literal["list_local_documents_action"] = "list_local_documents_action"  # type: ignore
+    kind: Literal["list_documents_action"] = "list_documents_action"  # type: ignore
 
 
 class ListDocumentsObservation(Observation):
@@ -96,11 +96,11 @@ class ListLocalDocuments(Tool):
     Tool to list all documents in the workspace directory.
     """
 
-    action: type[Action] = ListLocalDocumentsAction
+    action: type[Action] = ListDocumentsAction
     observation: type[Observation] = ListDocumentsObservation
     workspace_directory: str
 
-    def execute_action(self, action: ListLocalDocumentsAction) -> ListDocumentsObservation:
+    def execute_action(self, action: ListDocumentsAction) -> ListDocumentsObservation:
         try:
             documents = self.list_documents()
             return ListDocumentsObservation(documents=documents)

--- a/tapeagents/tools/document_reader.py
+++ b/tapeagents/tools/document_reader.py
@@ -72,12 +72,12 @@ class DocumentReader(Tool):
         return DocumentObservation(text=text, error=error)
 
 
-class ListDocumentsAction(Action):
+class ListLocalDocumentsAction(Action):
     """
     Action that lists all documents in the workspace directory.
     """
 
-    kind: Literal["list_documents_action"] = "list_documents_action"  # type: ignore
+    kind: Literal["list_local_documents_action"] = "list_local_documents_action"  # type: ignore
 
 
 class ListDocumentsObservation(Observation):
@@ -90,16 +90,16 @@ class ListDocumentsObservation(Observation):
     error: str | None = None
 
 
-class ListDocuments(Tool):
+class ListLocalDocuments(Tool):
     """
     Tool to list all documents in the workspace directory.
     """
 
-    action: type[Action] = ListDocumentsAction
+    action: type[Action] = ListLocalDocumentsAction
     observation: type[Observation] = ListDocumentsObservation
     workspace_directory: str
 
-    def execute_action(self, action: ListDocumentsAction) -> ListDocumentsObservation:
+    def execute_action(self, action: ListLocalDocumentsAction) -> ListDocumentsObservation:
         try:
             documents = self.list_documents()
             return ListDocumentsObservation(documents=documents)

--- a/tapeagents/tools/document_reader.py
+++ b/tapeagents/tools/document_reader.py
@@ -91,7 +91,7 @@ class ListDocumentsObservation(Observation):
     error: str | None = None
 
 
-class ListLocalDocuments(Tool):
+class ListDocuments(Tool):
     """
     Tool to list all documents in the workspace directory.
     """


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add a `MarkdownConverter` class to support conversion of Markdown documents including extracting titles, and rename classes related to listing documents to emphasize their local scope.

### Why are these changes being made?
Introducing the `MarkdownConverter` enhances the system's ability to handle Markdown files and extract meaningful content such as titles, which improves the document processing capabilities. The renaming of classes to `ListLocalDocuments` and related artifacts clarifies their functionality by explicitly indicating their operation within the local context, thus improving code readability and maintainability.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->