### PR TITLE
Pass `max_results_per_query` through parameters to WebSearch tool in MultiSearchExtract

### DIFF
--- a/tapeagents/tools/web_search.py
+++ b/tapeagents/tools/web_search.py
@@ -133,7 +133,7 @@ class WebSearch(Tool):
 
     action: type[Action] = SearchAction
     observation: type[Observation] = SearchResultsObservation
-    max_results: int = 5
+    max_results: int = Field(5, description="Maximum number of search results to request")
     cached: bool = True
 
     def execute_action(self, action: SearchAction) -> SearchResultsObservation:


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Pass `max_results_per_query` parameter to the WebSearch tool in the MultiSearchExtract class, allowing for customization of the maximum number of search results returned per query.

### Why are these changes being made?
These changes are being made to provide more control over search result management, making it possible to specify the maximum number of results to be processed per query which improves the flexibility and efficiency of search operations in varying use cases. This approach streamlines parameter management across related classes and ensures consistent behavior in search result handling.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->